### PR TITLE
fix: parse SUMO numbers with invariant culture

### DIFF
--- a/Assets/_Project/Scripts/RoadNetworkScripts/RoadNetworkBuilder.cs
+++ b/Assets/_Project/Scripts/RoadNetworkScripts/RoadNetworkBuilder.cs
@@ -111,17 +111,17 @@ public class RoadNetworkBuilder : MonoBehaviour
         if (!string.IsNullOrEmpty(netFile.Location?.ConvBoundary))
         {
             var bounds = netFile.Location.ConvBoundary.Split(',');
-            minX = float.Parse(bounds[0]);
-            minY = float.Parse(bounds[1]);
-            maxX = float.Parse(bounds[2]);
-            maxY = float.Parse(bounds[3]);
+            minX = SumoNumberParser.ParseFloat(bounds[0]);
+            minY = SumoNumberParser.ParseFloat(bounds[1]);
+            maxX = SumoNumberParser.ParseFloat(bounds[2]);
+            maxY = SumoNumberParser.ParseFloat(bounds[3]);
         }
 
         if (!string.IsNullOrEmpty(netFile.Location?.NetOffset))
         {
             var p = netFile.Location.NetOffset.Split(',');
-            originX = float.Parse(p[0]);
-            originY = float.Parse(p[1]);
+            originX = SumoNumberParser.ParseFloat(p[0]);
+            originY = SumoNumberParser.ParseFloat(p[1]);
         }
         else
         {
@@ -144,9 +144,9 @@ public class RoadNetworkBuilder : MonoBehaviour
                 var newJunction = new RoadJunctionData(
                     jt.Id,
                     jt.Type,
-                    float.Parse(jt.X),
-                    float.Parse(jt.Y),
-                    string.IsNullOrEmpty(jt.Z) ? 0f : float.Parse(jt.Z),
+                    SumoNumberParser.ParseFloat(jt.X),
+                    SumoNumberParser.ParseFloat(jt.Y),
+                    SumoNumberParser.ParseFloatOrDefault(jt.Z, 0f),
                     jt.IncLanes,
                     jt.Shape);
 
@@ -204,7 +204,9 @@ public class RoadNetworkBuilder : MonoBehaviour
                 foreach (string pair in poly.Shape.Split(' '))
                 {
                     var parts = pair.Split(',');
-                    shapeData.AddPoint(Convert.ToDouble(parts[0]), Convert.ToDouble(parts[1]));
+                    shapeData.AddPoint(
+                        SumoNumberParser.ParseDouble(parts[0]),
+                        SumoNumberParser.ParseDouble(parts[1]));
                 }
                 shapeData.RemoveDuplicateEndPoint();
                 if (!polygonShapes.ContainsKey(poly.Id))

--- a/Assets/_Project/Scripts/RoadNetworkScripts/RoadNetworkData.cs
+++ b/Assets/_Project/Scripts/RoadNetworkScripts/RoadNetworkData.cs
@@ -39,8 +39,8 @@ namespace Assets.Scripts.SUMOImporter.NetFileComponents
             foreach (string chunk in shapeStr.Split(' '))
             {
                 string[] xy = chunk.Split(',');
-                double xC = Convert.ToDouble(xy[0]);
-                double yC = Convert.ToDouble(xy[1]);
+                double xC = SumoNumberParser.ParseDouble(xy[0]);
+                double yC = SumoNumberParser.ParseDouble(xy[1]);
                 shapePoints.Add(new double[] { xC, yC });
             }
         }
@@ -115,8 +115,8 @@ namespace Assets.Scripts.SUMOImporter.NetFileComponents
                 foreach (string coordPair in shapeCoordinates.Split(' '))
                 {
                     string[] coords = coordPair.Split(',');
-                    double xC = Convert.ToDouble(coords[0]);
-                    double yC = Convert.ToDouble(coords[1]);
+                    double xC = SumoNumberParser.ParseDouble(coords[0]);
+                    double yC = SumoNumberParser.ParseDouble(coords[1]);
                     shapePoints.Add(new double[] { xC, yC });
                 }
             }

--- a/Assets/_Project/Scripts/RoadNetworkScripts/SumoNumberParser.cs
+++ b/Assets/_Project/Scripts/RoadNetworkScripts/SumoNumberParser.cs
@@ -1,0 +1,57 @@
+#if UNITY_EDITOR
+using System;
+using System.Globalization;
+
+namespace Assets.Scripts.SUMOImporter.NetFileComponents
+{
+    public static class SumoNumberParser
+    {
+        private const NumberStyles FloatingPointStyle = NumberStyles.Float;
+
+        public static double ParseDouble(string value)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+
+            return double.Parse(
+                value,
+                FloatingPointStyle,
+                CultureInfo.InvariantCulture);
+        }
+
+        public static float ParseFloat(string value)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+
+            return float.Parse(
+                value,
+                FloatingPointStyle,
+                CultureInfo.InvariantCulture);
+        }
+
+        public static float ParseFloatOrDefault(string value, float defaultValue)
+        {
+            return string.IsNullOrEmpty(value) ? defaultValue : ParseFloat(value);
+        }
+
+        public static bool TryParseDouble(string value, out double result)
+        {
+            return double.TryParse(
+                value,
+                FloatingPointStyle,
+                CultureInfo.InvariantCulture,
+                out result);
+        }
+
+        public static bool TryParseFloat(string value, out float result)
+        {
+            return float.TryParse(
+                value,
+                FloatingPointStyle,
+                CultureInfo.InvariantCulture,
+                out result);
+        }
+    }
+}
+#endif


### PR DESCRIPTION
<!--
Thank you for sending the PR!
PLEASE FILL OUT THE FOLLOWING TEMPLATE to help your reviewer test exactly the scope of the PR will entail.
-->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is being updated:

- Fixed culture-dependent parsing of numeric values from SUMO XML files.
- Updated SUMO numeric parsing to use `CultureInfo.InvariantCulture`.
- Updated road network, junction, lane, boundary, offset, and polygon coordinate parsing where applicable.
- Prevented values that use a dot as the decimal separator from being incorrectly parsed on systems using regional formats such as `pt-BR`.
- Fixed incorrectly scaled road networks and oversized polygons generated by `Create Road Network`.

The issue occurred because SUMO XML files always use a dot as the decimal separator, while some system cultures, such as Portuguese on Windows, use a comma. The importer previously relied on the system's current culture when parsing these values.

## Steps to test:

- Set the Windows regional format to Portuguese (Brazil), or use another locale where the decimal separator is a comma.
- Open the project using Unity Editor `6000.0.53f1`.
- Open the `Scenario1` scene.
- Go to `Sumo2Unity > Create Road Network`.
- Select a SUMO scenario containing both a `.net.xml` file and polygon data from a `.poly.xml` file.
- Generate the road network.
- Verify that the road network is visible and generated at the expected scale.
- Verify that polygons, such as grass areas, have the correct relative scale compared with the road network.
- Verify that Unity no longer reports extremely large triangles for `Polygon_po_0` caused by incorrectly parsed coordinates.
- Optionally repeat the test using an English regional format and confirm that the generated result is the same.

Before this fix, the road network could appear almost invisible while polygons were generated at an extremely large scale on Windows systems using the `pt-BR` regional format.

\_Note: Please test this using Unity Editor `6000.0.53f1`.

## Scope of the work

- [x] Sumo Unity Integration
- [ ] Unity Simulation
- [ ] Traffic Control
- [ ] Camera
- [ ] Data Recorder
- [ ] Canvas
- [ ] Asset Changes
- [ ] Scene Changes

## Link(s) to the issues being closed:

- No existing issue linked.